### PR TITLE
[WIP] Started porting to Linux + Meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,17 @@ Do not include parenthesis.
 
 Functions comparing two clips will compare testclip with source1. Some functions have threshold and offset parameters. 
 These parameters are not currently supported and are left at 0. If you need them, feel free to edit the code to parse parameter values.
+
+## Building
+
+Requirements:
+* meson
+* ninja
+* vapoursynth
+
+### Quick Start
+
+```
+meson build
+ninja -C build
+```

--- a/Src/Avisynth/avs/alignment.h
+++ b/Src/Avisynth/avs/alignment.h
@@ -52,7 +52,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstdint>
-#include "../Avisynth/avs/config.h"
+#include "config.h"
 
 #if defined(MSVC)
     // needed for VS2013, otherwise C++11 'alignas' works

--- a/Src/Avisynth/avs/win.h
+++ b/Src/Avisynth/avs/win.h
@@ -46,7 +46,7 @@
     #define NOMINMAX
 #endif
 
-#include <windows.h>
+// #include <windows.h>
 
 // Provision for UTF-8 max 4 bytes per code point
 #define AVS_MAX_PATH MAX_PATH*4

--- a/Src/Common/ContinuousMaskBase.cpp
+++ b/Src/Common/ContinuousMaskBase.cpp
@@ -62,10 +62,10 @@ template<typename T, typename P> void ContinuousMaskBase::Calculate(int width, i
 			if (srcIter[x] > thr)
 			{
 				Sum = 0;
-				radFwd = min(radius, width - x);
-				radBck = min(min(radius, x + 1), width) - 1;
-				radFwdV = min(radius, height - y);
-				radBckV = min(min(radius, y + 1), height) - 1;
+				radFwd = std::min(radius, width - x);
+				radBck = std::min(std::min(radius, x + 1), width) - 1;
+				radFwdV = std::min(radius, height - y);
+				radBckV = std::min(std::min(radius, y + 1), height) - 1;
 				for (int i = -radBck; i < radFwd; i++)
 				{
 					Sum += (T)srcIter[x + i];

--- a/Src/Common/ContinuousMaskBase.h
+++ b/Src/Common/ContinuousMaskBase.h
@@ -2,7 +2,8 @@
 #include "../Environments/Common.h"
 #include <cstring>
 #include <cstdint>
-#include <Windows.h>
+// #include <Windows.h>
+#include <algorithm>
 
 class ContinuousMaskBase
 {

--- a/Src/Common/ConvertFpsLimitBase.cpp
+++ b/Src/Common/ConvertFpsLimitBase.cpp
@@ -325,27 +325,27 @@ void ConvertFPSLimitBase::FloatToFPS(float n, uint32_t& num, uint32_t& den, ICom
 
 void ConvertFPSLimitBase::PresetToFPS(const char* p, uint32_t& num, uint32_t& den, ICommonEnvironment& env)
 {
-	if (lstrcmpi(p, "ntsc_film") == 0) { num = 24000; den = 1001; }
-	else if (lstrcmpi(p, "ntsc_video") == 0) { num = 30000; den = 1001; }
-	else if (lstrcmpi(p, "ntsc_double") == 0) { num = 60000; den = 1001; }
-	else if (lstrcmpi(p, "ntsc_quad") == 0) { num = 120000; den = 1001; }
+	if (strcasecmp(p, "ntsc_film") == 0) { num = 24000; den = 1001; }
+	else if (strcasecmp(p, "ntsc_video") == 0) { num = 30000; den = 1001; }
+	else if (strcasecmp(p, "ntsc_double") == 0) { num = 60000; den = 1001; }
+	else if (strcasecmp(p, "ntsc_quad") == 0) { num = 120000; den = 1001; }
 
-	else if (lstrcmpi(p, "ntsc_round_film") == 0) { num = 2997; den = 125; }
-	else if (lstrcmpi(p, "ntsc_round_video") == 0) { num = 2997; den = 100; }
-	else if (lstrcmpi(p, "ntsc_round_double") == 0) { num = 2997; den = 50; }
-	else if (lstrcmpi(p, "ntsc_round_quad") == 0) { num = 2997; den = 25; }
+	else if (strcasecmp(p, "ntsc_round_film") == 0) { num = 2997; den = 125; }
+	else if (strcasecmp(p, "ntsc_round_video") == 0) { num = 2997; den = 100; }
+	else if (strcasecmp(p, "ntsc_round_double") == 0) { num = 2997; den = 50; }
+	else if (strcasecmp(p, "ntsc_round_quad") == 0) { num = 2997; den = 25; }
 
-	else if (lstrcmpi(p, "film") == 0) { num = 24; den = 1; }
+	else if (strcasecmp(p, "film") == 0) { num = 24; den = 1; }
 
-	else if (lstrcmpi(p, "pal_film") == 0) { num = 25; den = 1; }
-	else if (lstrcmpi(p, "pal_video") == 0) { num = 25; den = 1; }
-	else if (lstrcmpi(p, "pal_double") == 0) { num = 50; den = 1; }
-	else if (lstrcmpi(p, "pal_quad") == 0) { num = 100; den = 1; }
+	else if (strcasecmp(p, "pal_film") == 0) { num = 25; den = 1; }
+	else if (strcasecmp(p, "pal_video") == 0) { num = 25; den = 1; }
+	else if (strcasecmp(p, "pal_double") == 0) { num = 50; den = 1; }
+	else if (strcasecmp(p, "pal_quad") == 0) { num = 100; den = 1; }
 
-	else if (lstrcmpi(p, "drop24") == 0) { num = 24000; den = 1001; }
-	else if (lstrcmpi(p, "drop30") == 0) { num = 30000; den = 1001; }
-	else if (lstrcmpi(p, "drop60") == 0) { num = 60000; den = 1001; }
-	else if (lstrcmpi(p, "drop120") == 0) { num = 120000; den = 1001; }
+	else if (strcasecmp(p, "drop24") == 0) { num = 24000; den = 1001; }
+	else if (strcasecmp(p, "drop30") == 0) { num = 30000; den = 1001; }
+	else if (strcasecmp(p, "drop60") == 0) { num = 60000; den = 1001; }
+	else if (strcasecmp(p, "drop120") == 0) { num = 120000; den = 1001; }
 	/*
 		else if (lstrcmpi(p, "drop25"           ) == 0) { num = 25000; den = 1001; }
 		else if (lstrcmpi(p, "drop50"           ) == 0) { num = 50000; den = 1001; }

--- a/Src/Common/ConvertFpsLimitBase.h
+++ b/Src/Common/ConvertFpsLimitBase.h
@@ -3,7 +3,10 @@
 #include "merge.h"
 #include <stdint.h>
 #include <cmath>
-#include <Windows.h>
+// #include <Windows.h>
+
+// Provide macro that's otherwise provided by Windows for multiplying two 32 bit floats into a single 64 bit.
+#define UInt32x32To64( a, b ) (unsigned long long)((unsigned long long)(a) * (b))
 
 // Class to change the framerate, attempting to smooth the transitions
 class ConvertFPSLimitBase

--- a/Src/Common/StripeMaskBase.cpp
+++ b/Src/Common/StripeMaskBase.cpp
@@ -178,7 +178,7 @@ void StripeMaskBase::CalcBand(BYTE* dst, int dstPitch, int size, BYTE* lineAvg, 
 					}
 					if (PatternLength > 0)
 					{
-						PatternStart = history[max(0, hLength - PatternLength * 2 - 2)].Pos;
+						PatternStart = history[std::max(0, hLength - PatternLength * 2 - 2)].Pos;
 					}
 				}
 				else if (PatternLength > 0)
@@ -224,8 +224,8 @@ int StripeMaskBase::GetDiff(BYTE* lineAvg, int n, int size, int compBck, int com
 		BYTE ValMax = ValMin;
 		for (int i = -compBck + 1; i <= compFwd; i++)
 		{
-			ValMin = min(ValMin, lineAvg[n + i]);
-			ValMax = max(ValMax, lineAvg[n + i]);
+			ValMin = std::min(ValMin, lineAvg[n + i]);
+			ValMax = std::max(ValMax, lineAvg[n + i]);
 		}
 		return ValMax - ValMin;
 	}

--- a/Src/Common/StripeMaskBase.h
+++ b/Src/Common/StripeMaskBase.h
@@ -1,7 +1,8 @@
 #include "../Environments/Common.h"
 #include <math.h>
 #include <cstring>
-#include <Windows.h>
+// #include <Windows.h>
+#include <algorithm>
 
 struct PatternStep {
 	PatternStep() {};

--- a/Src/Environments/Common.h
+++ b/Src/Environments/Common.h
@@ -84,7 +84,7 @@ struct ICommonEnvironment
 		const int MaxSize = 512;
 		const size_t NameLength = strlen(PluginName);
 		char Buffer[MaxSize]{ 0 };
-		strcpy_s(Buffer, PluginName);
+		strcpy(Buffer, PluginName);
 		Buffer[NameLength] = ':';
 		Buffer[NameLength + 1] = ' ';
 

--- a/Src/Environments/VpyFilter.hpp
+++ b/Src/Environments/VpyFilter.hpp
@@ -15,7 +15,7 @@ public:
 	const VSAPI* api;
 	VSMap* Out;
 
-	VpyFilter::VpyFilter(const char* pluginName, const VSMap* in, VSMap* out, VSNodeRef* node, VSCore* _core, const VSAPI* _api) :
+	VpyFilter(const char* pluginName, const VSMap* in, VSMap* out, VSNodeRef* node, VSCore* _core, const VSAPI* _api) :
 		Node(node), viSrc(_api->getVideoInfo(node)), viDst(*viSrc), api(_api), core(_core), Out(out)
 	{
 		PluginName2 = pluginName;
@@ -35,27 +35,29 @@ public:
 		return api->getError(Out);
 	}
 
-	virtual void VpyFilter::Init(VSMap* in, VSMap* out, VSNode* node, VpyEnvironment& env) = 0;
-	virtual VSFrameRef* VpyFilter::GetFrame(int n, int activationReason, void** frameData, VSFrameContext* frameCtx, VpyEnvironment& env) = 0;
-	virtual void VpyFilter::Free() = 0;
+	virtual void Init(VSMap* in, VSMap* out, VSNode* node, VpyEnvironment& env) = 0;
+	virtual VSFrameRef* GetFrame(int n, int activationReason, void** frameData, VSFrameContext* frameCtx, VpyEnvironment& env) = 0;
+	virtual void Free() = 0;
 
 
 
-	static void VS_CC VpyFilter::Init(VSMap* in, VSMap* out, void** instanceData, VSNode* node, VSCore* core, const VSAPI* api)
+	static void VS_CC Init(VSMap* in, VSMap* out, void** instanceData, VSNode* node, VSCore* core, const VSAPI* api)
 	{
 		VpyFilter* filter = (VpyFilter*)*instanceData;
-		filter->Init(in, out, node, VpyEnvironment(filter->PluginName2, api, core, out));
+		VpyEnvironment env = VpyEnvironment(filter->PluginName2, api, core, out);
+		filter->Init(in, out, node, env);
 		api->setVideoInfo(&filter->viDst, 1, node);
 	}
 
-	static const VSFrameRef* VS_CC VpyFilter::GetFrame(int n, int activationReason, void** instanceData, void** frameData, VSFrameContext* frameCtx, VSCore* core, const VSAPI* api)
+	static const VSFrameRef* VS_CC GetFrame(int n, int activationReason, void** instanceData, void** frameData, VSFrameContext* frameCtx, VSCore* core, const VSAPI* api)
 	{
 		VpyFilter* filter = (VpyFilter*)*instanceData;
+		VpyEnvironment env = VpyEnvironment(filter->PluginName2, api, core, frameCtx);
 		filter->core = core;
-		return filter->GetFrame(n, activationReason, frameData, frameCtx, VpyEnvironment(filter->PluginName2, api, core, frameCtx));
+		return filter->GetFrame(n, activationReason, frameData, frameCtx, env);
 	}
 
-	static void VS_CC VpyFilter::Free(void* instanceData, VSCore* core, const VSAPI* api)
+	static void VS_CC Free(void* instanceData, VSCore* core, const VSAPI* api)
 	{
 		VpyFilter* filter = (VpyFilter*)instanceData;
 		filter->core = core;

--- a/Src/VapourSynth/ContinuousMaskVpy.h
+++ b/Src/VapourSynth/ContinuousMaskVpy.h
@@ -8,7 +8,7 @@ public:
 	static void VS_CC Create(const VSMap* in, VSMap* out, void* userData, VSCore* core, const VSAPI* api);
 	ContinuousMaskVpy(const VSMap* in, VSMap* out, VSNodeRef* node, VSCore* core, const VSAPI* vsapi, int _radius, int _thr);
 	~ContinuousMaskVpy() {}
-	void VpyFilter::Init(VSMap* in, VSMap* out, VSNode* node, VpyEnvironment& env);
-	VSFrameRef* VpyFilter::GetFrame(int n, int activationReason, void** frameData, VSFrameContext* frameCtx, VpyEnvironment& env);
-	void VpyFilter::Free();
+	void Init(VSMap* in, VSMap* out, VSNode* node, VpyEnvironment& env) override;
+	VSFrameRef* GetFrame(int n, int activationReason, void** frameData, VSFrameContext* frameCtx, VpyEnvironment& env) override;
+	void Free() override;
 };

--- a/Src/VapourSynth/ConvertFpsLimitVpy.h
+++ b/Src/VapourSynth/ConvertFpsLimitVpy.h
@@ -16,9 +16,9 @@ public:
 
 	ConvertFpsLimitVpy(const VSMap* in, VSMap* out, VSNodeRef* node, VSCore* core, const VSAPI* vsapi, int new_numerator, int new_denominator, int _ratio);
 	~ConvertFpsLimitVpy() {}
-	void VpyFilter::Init(VSMap* in, VSMap* out, VSNode* node, VpyEnvironment& env);
-	VSFrameRef* VpyFilter::GetFrame(int n, int activationReason, void** frameData, VSFrameContext* frameCtx, VpyEnvironment& env);
-	void VpyFilter::Free();
+	void Init(VSMap* in, VSMap* out, VSNode* node, VpyEnvironment& env) override;
+	VSFrameRef* GetFrame(int n, int activationReason, void** frameData, VSFrameContext* frameCtx, VpyEnvironment& env) override;
+	void Free() override;
 };
 
 unsigned int gcd(unsigned int u, unsigned int v);

--- a/Src/VapourSynth/StripeMaskVpy.h
+++ b/Src/VapourSynth/StripeMaskVpy.h
@@ -8,7 +8,7 @@ public:
 	StripeMaskVpy(const VSMap* in, VSMap* out, VSCore* core, const VSAPI* api, VSNodeRef* node,
 		int _blksize, int _blksizev, int _overlap, int _overlapv, int _thr, int _comp, int _compv, int _str, bool _lines);
 	~StripeMaskVpy() {}
-	virtual void VpyFilter::Init(VSMap* in, VSMap* out, VSNode* node, VpyEnvironment& env);
-	virtual VSFrameRef* VpyFilter::GetFrame(int n, int activationReason, void** frameData, VSFrameContext* frameCtx, VpyEnvironment& env);
-	virtual void VpyFilter::Free();
+	virtual void Init(VSMap* in, VSMap* out, VSNode* node, VpyEnvironment& env);
+	virtual VSFrameRef* GetFrame(int n, int activationReason, void** frameData, VSFrameContext* frameCtx, VpyEnvironment& env);
+	virtual void Free();
 };

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,48 @@
+project('FrameRateConverter', 'cpp',
+    default_options: ['buildtype=release', 'b_ndebug=if-release', 'cpp_std=c++17'],
+  )
+
+sources = [
+  'Src/Common/ContinuousMaskBase.cpp',
+  'Src/Common/ConvertFpsLimitBase.cpp',
+  'Src/Common/StripeMaskBase.cpp',
+  'Src/Common/merge.cpp',
+  # 'Src/Common/merge_avx2.cpp',
+  'Src/Common/ContinuousMaskBase.cpp',
+  'Src/Environments/cpufeatures.cpp',
+  'Src/Environments/instrset_detect.cpp',
+  'Src/VapourSynth/ContinuousMaskVpy.cpp',
+  'Src/VapourSynth/ConvertFpsLimitVpy.cpp',
+  'Src/VapourSynth/InitVpy.cpp',
+  'Src/VapourSynth/StripeMaskVpy.cpp',
+  # 'Src/Avisynth/ContinuousMaskAvs.cpp',
+  # 'Src/Avisynth/ConvertFpsLimitAvs.cpp',
+  # 'Src/Avisynth/InitAvs.cpp',
+  # 'Src/Avisynth/StripeMaskAvs.cpp',
+  # 'Src/Avisynth/conditional.cpp',
+  # 'Src/Avisynth/conditional_functions.cpp',
+]
+
+vapoursynth_dep = dependency('vapoursynth', version: '>=55').partial_dependency(compile_args : true, includes : true)
+
+deps = [vapoursynth_dep]
+libs = []
+
+if host_machine.cpu_family().startswith('x86')
+    add_project_arguments('-mfpmath=sse', '-msse2', language : ['c', 'cpp'])
+
+    libs += static_library('merge_avx2', 'Src/Common/merge_avx2.cpp',
+                # dependencies: [m_dep],
+                cpp_args: ['-mavx2', '-mfma'],
+                pic: true,
+                # include_directories: includedirs
+            )
+endif
+
+shared_module('framerateconverter', sources,
+  dependencies : deps,
+  link_with : libs,
+  install : true,
+  install_dir : join_paths(vapoursynth_dep.get_pkgconfig_variable('libdir'), 'vapoursynth'),
+  gnu_symbol_visibility : 'hidden'
+)


### PR DESCRIPTION
This is still a work in progress. Fixes #5 

There are a few errors around concerning non-const lvalues, rvalues, wrt certain constructor calls.

References (meson build examples):
1. https://github.com/Irrational-Encoding-Wizardry/descale/blob/master/meson.build
1. https://github.com/vapoursynth/vivtc/blob/master/meson.build

TODO:
1. Fix non-const lvalue / rvalue errors.
2. Get vapoursynth build working.
3. Get avisynth+ build working.
4. Support cross-compilation for windows support.

---

Current issues I'm encountering, in part because of my limited knowledge of c++: 

### Build failing due to non-const lvalue
```
../Src/VapourSynth/ContinuousMaskVpy.cpp: In constructor ‘ContinuousMaskVpy::ContinuousMaskVpy(const VSMap*, VSMap*, VSNodeRef*, VSCore*, const VSAPI*, int, int)’:
../Src/VapourSynth/ContinuousMaskVpy.cpp:16:53: error: cannot bind non-const lvalue reference of type ‘ICommonEnvironment&’ to an rvalue of type ‘ICommonEnvironment’
   16 |         ContinuousMaskBase(new VpyVideo(node, api), VpyEnvironment(PluginName, api, core, out), _radius, _thr)
      |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../Src/VapourSynth/ContinuousMaskVpy.h:3:
../Src/VapourSynth/../Common/ContinuousMaskBase.h:20:70: note:   initializing argument 2 of ‘ContinuousMaskBase::ContinuousMaskBase(ICommonVideo*, ICommonEnvironment&, int, int)’
   20 |         ContinuousMaskBase(ICommonVideo* _child, ICommonEnvironment& _env, int _radius, int _thr);
      |                                                  ~~~~~~~~~~~~~~~~~~~~^~~~
```

### Avisynth builds
I've been focused on the Vapoursynth components and haven't turned on Avisynth building just yet. Not sure what monsters lie there.